### PR TITLE
Use multiple compilers in the travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ addons:
       - qt5-default
       - qt5-qmake
 
-compiler:
-  - gcc
-  - clang
+matrix:
+  include:
+    - compiler: gcc
+      env: QMAKESPEC=linux-g++
+    - compiler: clang
+      env: QMAKESPEC=linux-clang
 
 script:
   - qmake -qt=qt5


### PR DESCRIPTION
Setting the "compiler" option to gcc or clang has no effect on qmake, setting the QMAKESPEC environment variable is also necessary.